### PR TITLE
Clang tidy

### DIFF
--- a/cc/ccsh_compiler.cpp
+++ b/cc/ccsh_compiler.cpp
@@ -65,7 +65,7 @@ std::vector<std::string>::const_iterator find_file(std::vector<std::string> cons
     {
         if ((*it)[0] == '-')
         {
-            if (gcc_options_with_args.count(*it))
+            if (gcc_options_with_args.count(*it) != 0)
                 ++it;
         }
         else if ((*it)[0] != '@')

--- a/cc/ccsh_compiler.cpp
+++ b/cc/ccsh_compiler.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
     for (int i = 1; i < argc; ++i)
     {
         if (argv[i] != compile_only_str)
-            args.push_back(argv[i]);
+            args.emplace_back(argv[i]);
         else
             compile_only = true;
     }
@@ -125,10 +125,10 @@ int main(int argc, char** argv)
 
     std::vector<std::string> gcc_args;
     gcc_args.reserve(file_it - args.begin() + 5);
-    gcc_args.push_back("-x");
-    gcc_args.push_back("c++");
-    gcc_args.push_back("-l");
-    gcc_args.push_back("ccsh_lib");
+    gcc_args.emplace_back("-x");
+    gcc_args.emplace_back("c++");
+    gcc_args.emplace_back("-l");
+    gcc_args.emplace_back("ccsh_lib");
 
     for (auto it = args.begin(); it != file_it; ++it)
     {
@@ -143,9 +143,9 @@ int main(int argc, char** argv)
 
     temp /= generate_filename();
 
-    gcc_args.push_back("-o");
+    gcc_args.emplace_back("-o");
     gcc_args.push_back(temp.string());
-    gcc_args.push_back("-");
+    gcc_args.emplace_back("-");
 
     std::string cxx = ccsh::$("CXX");
     if (cxx.empty())

--- a/cc/ccsh_compiler.cpp
+++ b/cc/ccsh_compiler.cpp
@@ -4,14 +4,14 @@
 
 #include <ccsh/ccsh.hpp>
 
-#include <iostream>
 #include <algorithm>
-#include <vector>
-#include <string>
-#include <random>
-#include <unordered_set>
-#include <fstream>
 #include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 #include <unistd.h>
 

--- a/include/ccsh/CWrapper.hpp
+++ b/include/ccsh/CWrapper.hpp
@@ -1,10 +1,10 @@
-#ifndef CWRAPPER_HPP_INCLUDED
-#define CWRAPPER_HPP_INCLUDED
+#ifndef CCSH_CWRAPPER_HPP
+#define CCSH_CWRAPPER_HPP
 
 /** https://github.com/dobragab/CWrapper */
 
-#include <utility>
 #include <exception>
+#include <utility>
 
 #define HAS_STATIC_MEMBER_DETECTOR(member)                                  \
 template<typename T>                                                        \
@@ -368,7 +368,8 @@ template<
     CWrapperType TYPE = CWrapperType::Get,
     bool CONSTSAFE = true>
 using CWrapper = typename CWrapperFriend<HANDLE_T, FUNCTIONS, TYPE, CONSTSAFE>::type;
-}
+
+} // namespace CW
 
 #undef HAS_STATIC_MEMBER_DETECTOR
 #undef HAS_STATIC_MEMBER
@@ -376,4 +377,4 @@ using CWrapper = typename CWrapperFriend<HANDLE_T, FUNCTIONS, TYPE, CONSTSAFE>::
 #undef HAS_NESTED_TYPE
 
 
-#endif // CWRAPPER_HPP_INCLUDED
+#endif // CCSH_CWRAPPER_HPP

--- a/include/ccsh/CWrapper.hpp
+++ b/include/ccsh/CWrapper.hpp
@@ -53,7 +53,7 @@ enum class CWrapperType
 
 struct CWrapperException : public std::exception
 {
-    virtual const char* what() const noexcept override
+    const char* what() const noexcept override
     {
         return "CWrapperException";
     }

--- a/include/ccsh/CWrapper.hpp
+++ b/include/ccsh/CWrapper.hpp
@@ -277,7 +277,7 @@ class CWrapperFriend
             CWrapperBase{FUNCTIONS::ctor_func(std::forward<ARGS>(args)...)}
         { }
 
-        CWrapperBase(CWrapperBase&& old)
+        CWrapperBase(CWrapperBase&& old) noexcept
             :
             CWrapperBase{old.ptr}
         {
@@ -297,7 +297,7 @@ class CWrapperFriend
                 FUNCTIONS::dtor_func(ptr);
         }
 
-        CWrapperBase& operator=(CWrapperBase other)
+        CWrapperBase& operator=(CWrapperBase other) noexcept
         {
             std::swap(ptr, other.ptr);
             return *this;

--- a/include/ccsh/builtins/cd.hpp
+++ b/include/ccsh/builtins/cd.hpp
@@ -3,6 +3,8 @@
 
 #include "../ccsh_command.hpp"
 
+#include <utility>
+
 namespace ccsh {
 
 class cd_t : public internal::command_builtin
@@ -13,8 +15,8 @@ class cd_t : public internal::command_builtin
     bool helpflag = false;
 
 public:
-    cd_t(fs::path const& p = get_home())
-        : p(p)
+    explicit cd_t(fs::path p = get_home())
+        : p(std::move(p))
     { }
 
     command_holder<cd_t>& P()
@@ -41,7 +43,7 @@ public:
         return static_cast<command_holder<cd_t>&>(*this);
     }
 
-    int runx(int in, int out, int err) const override final;
+    int runx(int in, int out, int err) const final;
 };
 
 using cd = command_holder<cd_t>;

--- a/include/ccsh/builtins/cd.hpp
+++ b/include/ccsh/builtins/cd.hpp
@@ -1,5 +1,5 @@
-#ifndef CCSH_CD_HPP_INCLUDED
-#define CCSH_CD_HPP_INCLUDED
+#ifndef CCSH_BUILTINS_CD_HPP
+#define CCSH_BUILTINS_CD_HPP
 
 #include "../ccsh_command.hpp"
 
@@ -49,6 +49,6 @@ public:
 using cd = command_holder<cd_t>;
 
 
-}
+} // namespace ccsh
 
-#endif // CCSH_CD_HPP_INCLUDED
+#endif // CCSH_BUILTINS_CD_HPP

--- a/include/ccsh/builtins/pwd.hpp
+++ b/include/ccsh/builtins/pwd.hpp
@@ -1,5 +1,5 @@
-#ifndef CCSH_PWD_HPP_INCLUDED
-#define CCSH_PWD_HPP_INCLUDED
+#ifndef CCSH_BUILTINS_PWD_HPP
+#define CCSH_BUILTINS_PWD_HPP
 
 #include "../ccsh_command.hpp"
 
@@ -42,6 +42,6 @@ public:
 using pwd = command_holder<pwd_t>;
 
 
-}
+} // namespace ccsh
 
-#endif // CCSH_PWD_HPP_INCLUDED
+#endif // CCSH_BUILTINS_PWD_HPP

--- a/include/ccsh/builtins/pwd.hpp
+++ b/include/ccsh/builtins/pwd.hpp
@@ -3,6 +3,8 @@
 
 #include "../ccsh_command.hpp"
 
+#include <utility>
+
 namespace ccsh {
 
 class pwd_t : public internal::command_builtin
@@ -12,8 +14,8 @@ class pwd_t : public internal::command_builtin
     bool helpflag = false;
 
 public:
-    pwd_t(fs::path const& p = get_home())
-        : p(p)
+    explicit pwd_t(fs::path p = get_home())
+        : p(std::move(p))
     { }
 
     command_holder<pwd_t>& P()
@@ -34,7 +36,7 @@ public:
         return static_cast<command_holder<pwd_t>&>(*this);
     }
 
-    int runx(int in, int out, int err) const override final;
+    int runx(int in, int out, int err) const final;
 };
 
 using pwd = command_holder<pwd_t>;

--- a/include/ccsh/ccsh.hpp
+++ b/include/ccsh/ccsh.hpp
@@ -1,16 +1,16 @@
-#ifndef CCSH_HPP_INCLUDED
-#define CCSH_HPP_INCLUDED
+#ifndef CCSH_CCSH_HPP
+#define CCSH_CCSH_HPP
 
 // In order to use non-standard dollar functions, e.g. $("USER")
 // you need to define CCSH_NON_STANDARD_DOLLAR
 
 #include "ccsh_utils.hpp"
-#include "ccsh_regex.hpp"
-#include "ccsh_command.hpp"
-#include "ccsh_operators.hpp"
-#include "ccsh_tty.hpp"
 #include "ccsh_builtins.hpp"
+#include "ccsh_command.hpp"
 #include "ccsh_fdstream.hpp"
+#include "ccsh_operators.hpp"
+#include "ccsh_regex.hpp"
+#include "ccsh_tty.hpp"
 
 
-#endif // CCSH_HPP_INCLUDED
+#endif // CCSH_CCSH_HPP

--- a/include/ccsh/ccsh_builtins.hpp
+++ b/include/ccsh/ccsh_builtins.hpp
@@ -1,7 +1,7 @@
-#ifndef CCSH_CCSH_BUILTINS_HPP_INCLUDED
-#define CCSH_CCSH_BUILTINS_HPP_INCLUDED
+#ifndef CCSH_CCSH_BUILTINS_HPP
+#define CCSH_CCSH_BUILTINS_HPP
 
 #include "builtins/cd.hpp"
 #include "builtins/pwd.hpp"
 
-#endif // CCSH_CCSH_BUILTINS_HPP_INCLUDED
+#endif // CCSH_CCSH_BUILTINS_HPP

--- a/include/ccsh/ccsh_command.hpp
+++ b/include/ccsh/ccsh_command.hpp
@@ -1,15 +1,15 @@
-#ifndef CCSH_COMMAND_HPP_INCLUDED
-#define CCSH_COMMAND_HPP_INCLUDED
+#ifndef CCSH_CCSH_COMMAND_HPP
+#define CCSH_CCSH_COMMAND_HPP
 
 #include "ccsh_utils.hpp"
 
-#include <string>
-#include <memory>
-#include <vector>
 #include <cstddef>
 #include <functional>
 #include <future>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace ccsh {
 namespace internal {
@@ -478,4 +478,4 @@ inline command command_make(internal::command_functor func)
 } // namespace ccsh
 
 
-#endif // CCSH_COMMAND_HPP_INCLUDED
+#endif // CCSH_CCSH_COMMAND_HPP

--- a/include/ccsh/ccsh_command.hpp
+++ b/include/ccsh/ccsh_command.hpp
@@ -307,7 +307,7 @@ class command_bool final : public command_base
 {
     bool b;
 public:
-    command_bool(bool b)
+    explicit command_bool(bool b)
         : b(b)
     { }
 
@@ -419,7 +419,7 @@ class command_source final : public command_base, protected command_async
     std::string cmdstr;
 
 public:
-    command_source(fs::path const& p, std::vector<std::string> const& args = {});
+    explicit command_source(fs::path const& p, std::vector<std::string> const& args = {});
 
     void start_run(int in, int out, int err, std::vector<int>) const override;
 
@@ -454,7 +454,7 @@ class command_function : public command_base, protected command_async
 {
     command_functor func;
 public:
-    command_function(command_functor func)
+    explicit command_function(command_functor func)
         : func(std::move(func))
     { }
 
@@ -473,7 +473,7 @@ using internal::command_holder;  // easier for wrappers
 
 inline command command_make(internal::command_functor func)
 {
-    return {new internal::command_function{std::move(func)}};
+    return internal::command_runnable{new internal::command_function{std::move(func)}};
 }
 } // namespace ccsh
 

--- a/include/ccsh/ccsh_command.hpp
+++ b/include/ccsh/ccsh_command.hpp
@@ -254,7 +254,7 @@ public:
             int lres = this->left.finish_run();
             if (!start_right(lres))
                 return lres;
-            this->right.start_run(in, out, err, std::move(unused_fds));
+            this->right.start_run(in, out, err, unused_fds);
             return this->right.finish_run();
         };
 

--- a/include/ccsh/ccsh_command.hpp
+++ b/include/ccsh/ccsh_command.hpp
@@ -316,7 +316,7 @@ public:
 
     int finish_run() const override
     {
-        return !b; // logical inversion of shell logic
+        return int(!b); // logical inversion of shell logic
     }
 };
 

--- a/include/ccsh/ccsh_fdstream.hpp
+++ b/include/ccsh/ccsh_fdstream.hpp
@@ -1,10 +1,10 @@
-#ifndef CCSH_CCSH_FDSTREAM_HPP_INCLUDED
-#define CCSH_CCSH_FDSTREAM_HPP_INCLUDED
+#ifndef CCSH_CCSH_FDSTREAM_HPP
+#define CCSH_CCSH_FDSTREAM_HPP
 
-#include <iostream>
 #include <array>
-#include <memory>
 #include <cstdio>
+#include <iostream>
+#include <memory>
 
 namespace ccsh {
 
@@ -61,7 +61,7 @@ private:
     int_type underflow() override;
 };
 
-}
+} // namespace internal
 
 class ofdstream : public std::ostream
 {
@@ -83,6 +83,6 @@ public:
     { }
 };
 
-}
+} // namespace ccsh
 
-#endif //CCSH_CCSH_FDSTREAM_HPP_INCLUDED
+#endif // CCSH_CCSH_FDSTREAM_HPP

--- a/include/ccsh/ccsh_fdstream.hpp
+++ b/include/ccsh/ccsh_fdstream.hpp
@@ -52,13 +52,13 @@ public:
         setg(end, end, end);
     }
 
-private:
-    int_type underflow() override;
-
     ifdstreambuf(ifdstreambuf&&) = default;
     ifdstreambuf(ifdstreambuf const&) = delete;
     ifdstreambuf& operator=(ifdstreambuf&&) = default;
     ifdstreambuf& operator=(ifdstreambuf const&) = delete;
+
+private:
+    int_type underflow() override;
 };
 
 }

--- a/include/ccsh/ccsh_filesystem.hpp
+++ b/include/ccsh/ccsh_filesystem.hpp
@@ -1,5 +1,5 @@
-#ifndef CCSH_FILESYSTEM_HPP_INCLUDED
-#define CCSH_FILESYSTEM_HPP_INCLUDED
+#ifndef CCSH_CCSH_FILESYSTEM_HPP
+#define CCSH_CCSH_FILESYSTEM_HPP
 
 #ifdef CCSH_FILESYSTEM_BOOST
 
@@ -13,24 +13,29 @@
 #    include <boost/filesystem.hpp>
 #endif
 
-namespace ccsh { namespace fs {
+namespace ccsh {
+namespace fs {
 using namespace boost::filesystem;
 using boost::system::error_code;
-}}
+} // namespace fs
+} // namespace ccsh
 
 #else
 
-#include <system_error>
 #include <experimental/filesystem>
+#include <system_error>
 
-namespace ccsh { namespace fs {
+namespace ccsh {
+namespace fs {
 using namespace std::experimental::filesystem;
 using std::error_code;
-}}
+} // namespace fs
+} // namespace ccsh
 
 #endif
 
-namespace ccsh { namespace fs {
+namespace ccsh {
+namespace fs {
 
 path self_lexically_relative(path const& self, path const& base);
 path self_lexically_normal(path const& self);
@@ -39,6 +44,7 @@ path self_lexically_normal(path const& self);
 path relative(path const& p, path const& base, fs::error_code& ec);
 #endif
 
-}}
+} // namespace fs
+} // namespace ccsh
 
-#endif // CCSH_FILESYSTEM_HPP_INCLUDED
+#endif // CCSH_CCSH_FILESYSTEM_HPP

--- a/include/ccsh/ccsh_operators.hpp
+++ b/include/ccsh/ccsh_operators.hpp
@@ -85,11 +85,11 @@ command_runnable operator>=(command const& c, std::string& str);
 
 /* ******************* vector redirection operators ******************* */
 
-command_runnable operator<(command const& c, std::vector<std::string>& str);
-command_runnable operator>>(command const& c, std::vector<std::string>& str);
-command_runnable operator>(command const& c, std::vector<std::string>& str);
-command_runnable operator>>=(command const& c, std::vector<std::string>& str);
-command_runnable operator>=(command const& c, std::vector<std::string>& str);
+command_runnable operator<(command const& c, std::vector<std::string>& vec);
+command_runnable operator>>(command const& c, std::vector<std::string>& vec);
+command_runnable operator>(command const& c, std::vector<std::string>& vec);
+command_runnable operator>>=(command const& c, std::vector<std::string>& vec);
+command_runnable operator>=(command const& c, std::vector<std::string>& vec);
 
 /* ******************* vector redirection operators ******************* */
 

--- a/include/ccsh/ccsh_operators.hpp
+++ b/include/ccsh/ccsh_operators.hpp
@@ -1,5 +1,5 @@
-#ifndef CCSH_OPERATORS_HPP_INCLUDED
-#define CCSH_OPERATORS_HPP_INCLUDED
+#ifndef CCSH_CCSH_OPERATORS_HPP
+#define CCSH_CCSH_OPERATORS_HPP
 
 #include "ccsh_command.hpp"
 #include <iostream>
@@ -236,4 +236,4 @@ inline std::ostream& operator<<(std::ostream& os, env_var const& var)
 } // namespace ccsh
 
 
-#endif // CCSH_OPERATORS_HPP_INCLUDED
+#endif // CCSH_CCSH_OPERATORS_HPP

--- a/include/ccsh/ccsh_ratio.hpp
+++ b/include/ccsh/ccsh_ratio.hpp
@@ -1,9 +1,9 @@
-#ifndef CCSH_RATIO_HPP_INCLUDED
-#define CCSH_RATIO_HPP_INCLUDED
+#ifndef CCSH_CCSH_RATIO_HPP
+#define CCSH_CCSH_RATIO_HPP
 
-#include <string>
-#include <ratio>
 #include <cstdint>
+#include <ratio>
+#include <string>
 
 namespace ccsh {
 
@@ -77,4 +77,4 @@ std::string quantity_to_string(quantity<RATIO> q)
 }
 } // namespace ccsh
 
-#endif // CCSH_RATIO_HPP_INCLUDED
+#endif // CCSH_CCSH_RATIO_HPP

--- a/include/ccsh/ccsh_regex.hpp
+++ b/include/ccsh/ccsh_regex.hpp
@@ -1,5 +1,5 @@
-#ifndef CCSH_REGEX_HPP_INCLUDED
-#define CCSH_REGEX_HPP_INCLUDED
+#ifndef CCSH_CCSH_REGEX_HPP
+#define CCSH_CCSH_REGEX_HPP
 
 #include "ccsh_utils.hpp"
 
@@ -53,6 +53,7 @@ public:
         return ex;
     }
 };
-}
 
-#endif // CCSH_REGEX_HPP_INCLUDED
+} // namespace ccsh
+
+#endif // CCSH_CCSH_REGEX_HPP

--- a/include/ccsh/ccsh_tty.hpp
+++ b/include/ccsh/ccsh_tty.hpp
@@ -1,8 +1,8 @@
-#ifndef CCSH_TTY_HPP_INCLUDED
-#define CCSH_TTY_HPP_INCLUDED
+#ifndef CCSH_CCSH_TTY_HPP
+#define CCSH_CCSH_TTY_HPP
 
-#include <iostream>
 #include <cstdint>
+#include <iostream>
 
 namespace ccsh { namespace tty {
 
@@ -63,7 +63,9 @@ inline std::ostream& operator<<(std::ostream& os, tty::bg_color m)
 {
     return printty(os, m);
 }
-}}
+
+} // namespace tty
+} // namespace ccsh
 
 
-#endif // CCSH_TTY_HPP_INCLUDED
+#endif // CCSH_CCSH_TTY_HPP

--- a/include/ccsh/ccsh_utils.hpp
+++ b/include/ccsh/ccsh_utils.hpp
@@ -1,10 +1,10 @@
-#ifndef CCSH_UTILS_HPP_INCLUDED
-#define CCSH_UTILS_HPP_INCLUDED
+#ifndef CCSH_CCSH_UTILS_HPP
+#define CCSH_CCSH_UTILS_HPP
 
+#include <cstddef>
 #include <exception>
 #include <stdexcept>
 #include <string>
-#include <cstddef>
 
 #include "ccsh_filesystem.hpp"
 
@@ -15,7 +15,8 @@ namespace ccsh {
 namespace fs {
 std::vector<path> expand(path const& p);
 std::vector<path> expand(std::vector<path> const& paths);
-}
+} // namespace fs
+
 // NEVER EVER USE boost::filesystem DIRECTLY, ALWAYS USE ccsh::fs
 // boost::filesystem WILL BE CHANGED TO std::filesystem WITH C++17
 
@@ -97,4 +98,4 @@ enum class stdfd : uint8_t
 
 } // namespace ccsh
 
-#endif // CCSH_UTILS_HPP_INCLUDED
+#endif // CCSH_CCSH_UTILS_HPP

--- a/include/ccsh/ccsh_utils.hpp
+++ b/include/ccsh/ccsh_utils.hpp
@@ -37,7 +37,7 @@ class stdc_error : public std::runtime_error
 {
     int error_number;
 public:
-    stdc_error(int no = errno);
+    explicit stdc_error(int no = errno);
     stdc_error(int no, std::string const& msg);
 
     int no() const
@@ -60,7 +60,7 @@ public:
     static void set(std::string const& name, std::string const& value, bool override = true);
     static int try_set(std::string const& name, std::string const& value, bool override = true);
 
-    env_var(std::string name)
+    explicit env_var(std::string name)
         : name(std::move(name))
     { }
 

--- a/include/ccsh/ccsh_wrappers.hpp
+++ b/include/ccsh/ccsh_wrappers.hpp
@@ -1,9 +1,9 @@
-#ifndef CCSH_WRAPPERS_HPP_INCLUDED
-#define CCSH_WRAPPERS_HPP_INCLUDED
+#ifndef CCSH_CCSH_WRAPPERS_HPP
+#define CCSH_CCSH_WRAPPERS_HPP
 
 #include "ccsh_command.hpp"
-#include <utility>
 #include <string>
+#include <utility>
 
 #define MAGIC(x) (void)swallow{0, ((void)(x), 0)...}
 
@@ -166,7 +166,7 @@ public:
 
 #undef MAGIC
 
-}
-}
+} // namespace wrappers
+} // namespace ccsh
 
-#endif // CCSH_WRAPPERS_HPP_INCLUDED
+#endif // CCSH_CCSH_WRAPPERS_HPP

--- a/include/ccsh/ccsh_wrappers.hpp
+++ b/include/ccsh/ccsh_wrappers.hpp
@@ -142,12 +142,12 @@ public:
         : command_native(DERIVED::name())
     { }
 
-    options_paths(std::vector<fs::path> const& paths)
+    explicit options_paths(std::vector<fs::path> const& paths)
         : command_native(DERIVED::name())
         , paths(fs::expand(paths))
     { }
 
-    options_paths(fs::path const& p)
+    explicit options_paths(fs::path const& p)
         : command_native(DERIVED::name())
         , paths(fs::expand(p))
     { }

--- a/include/ccsh/ccsh_wrappers.hpp
+++ b/include/ccsh/ccsh_wrappers.hpp
@@ -140,7 +140,6 @@ public:
 
     options_paths()
         : command_native(DERIVED::name())
-        , paths()
     { }
 
     options_paths(std::vector<fs::path> const& paths)

--- a/include/ccsh/ccsh_wrappers.hpp
+++ b/include/ccsh/ccsh_wrappers.hpp
@@ -59,15 +59,15 @@ class options_paths : public internal::command_native
 protected:
     std::vector<fs::path> paths;
 
-    virtual std::vector<const char*> get_argv() const override final
+    std::vector<const char*> get_argv() const final
     {
         std::vector<const char*> argv = internal::command_native::get_argv();
         argv.reserve(argv.size() + paths.size());
         argv.pop_back();
         for (const auto& p : paths)
-            argv.push_back(p.c_str());
+            argv.emplace_back(p.c_str());
 
-        argv.push_back(nullptr);
+        argv.emplace_back(nullptr);
         return argv;
     }
 
@@ -105,7 +105,7 @@ protected:
     command_holder <DERIVED>& add_larg_s(const char* name, ARG&& arg)
     {
         args.emplace_back(name);
-        args.push_back(arg);
+        args.push_back(std::forward<ARG>(arg));
         return static_cast<command_holder<DERIVED>&>(*this);
     }
 
@@ -113,7 +113,7 @@ protected:
     command_holder <DERIVED>&& add_rarg_s(const char* name, ARG&& arg)
     {
         args.emplace_back(name);
-        args.push_back(arg);
+        args.push_back(std::forward<ARG>(arg));
         return std::move(static_cast<command_holder<DERIVED>&>(*this));
     }
 
@@ -123,7 +123,7 @@ protected:
         std::string res = name;
         using swallow = int[];
         MAGIC(res += arg);
-        args.push_back(res);
+        args.push_back(std::move(res));
         return static_cast<command_holder<DERIVED>&>(*this);
     }
     template<typename... ARG>
@@ -132,7 +132,7 @@ protected:
         std::string res = name;
         using swallow = int[];
         MAGIC(res += arg);
-        args.push_back(res);
+        args.push_back(std::move(res));
         return std::move(static_cast<command_holder<DERIVED>&>(*this));
     }
 

--- a/lib/builtins/cd.cpp
+++ b/lib/builtins/cd.cpp
@@ -29,11 +29,11 @@ int change_to_directory(path newdir, bool follow_symlinks)
 
     // Use the canonicalized version of NEWDIR, or, if canonicalization
     // failed, use the non-canonical form.
-    bool canon_failed = 0;
+    bool canon_failed = false;
     if (ec)
     {
         tdir = tcwd;
-        canon_failed = 1;
+        canon_failed = true;
     }
 
     // In POSIX mode, if we're resolving symlinks logically and sh_canonpath
@@ -134,7 +134,7 @@ int cd_t::runx(int, int out_fd, int err_fd) const
     bool printflag = false;
     bool eflag = this->eflag;
     if (eflag && follow_symlinks)
-        eflag = 0;
+        eflag = false;
 
     const char* dirname = p.c_str();
 

--- a/lib/builtins/cd.cpp
+++ b/lib/builtins/cd.cpp
@@ -60,8 +60,8 @@ int change_to_directory(path newdir, bool follow_symlinks)
     int err = errno;
     if (chdir(newdir.c_str()) == 0)
         return EXIT_SUCCESS;
-    else
-        errno = err;
+
+    errno = err;
     return EXIT_FAILURE;
 }
 

--- a/lib/builtins/cd.cpp
+++ b/lib/builtins/cd.cpp
@@ -1,9 +1,9 @@
-#include <ccsh/builtins/cd.hpp>
-#include <ccsh/ccsh_operators.hpp>
-#include <ccsh/ccsh_fdstream.hpp>
 #include "../ccsh_internals.hpp"
-#include <cstring>
+#include <ccsh/builtins/cd.hpp>
+#include <ccsh/ccsh_fdstream.hpp>
+#include <ccsh/ccsh_operators.hpp>
 #include <cstdlib>
+#include <cstring>
 
 namespace {
 
@@ -191,5 +191,5 @@ int cd_t::runx(int, int out_fd, int err_fd) const
     return EXIT_FAILURE;
 }
 
-}
+} // namespace ccsh
 

--- a/lib/builtins/pwd.cpp
+++ b/lib/builtins/pwd.cpp
@@ -1,6 +1,6 @@
+#include "../ccsh_internals.hpp"
 #include <ccsh/builtins/pwd.hpp>
 #include <ccsh/ccsh_fdstream.hpp>
-#include "../ccsh_internals.hpp"
 
 namespace {
 
@@ -50,4 +50,5 @@ int pwd_t::runx(int, int out_fd, int) const
 
     return EXIT_SUCCESS;
 }
-}
+
+} // namespace ccsh

--- a/lib/ccsh_command.cpp
+++ b/lib/ccsh_command.cpp
@@ -302,7 +302,7 @@ void env_putter(std::string const& str)
     std::string env_name = str.substr(0, eq_sign);
     std::string env_value = str.substr(++eq_sign);
 
-    stdc_thrower(setenv(env_name.c_str(), env_value.c_str(), true));
+    stdc_thrower(setenv(env_name.c_str(), env_value.c_str(), int(true)));
 }
 
 auto env_applier = [](open_wrapper fd) -> int

--- a/lib/ccsh_command.cpp
+++ b/lib/ccsh_command.cpp
@@ -1,13 +1,13 @@
-#include <ccsh/ccsh_command.hpp>
 #include "ccsh_internals.hpp"
+#include <ccsh/ccsh_command.hpp>
 
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <cstdio>
 #include <unistd.h>
-#include <cstring>
 
 #include <iostream>
 #include <utility>
@@ -317,7 +317,7 @@ auto env_applier = [](open_wrapper fd) -> int
     return 0;
 };
 
-}
+}  // namespace
 
 command_source::command_source(fs::path const& p, std::vector<std::string> const& args)
     : cmd("/bin/sh", {"-c", ""})

--- a/lib/ccsh_command.cpp
+++ b/lib/ccsh_command.cpp
@@ -307,7 +307,7 @@ void env_putter(std::string const& str)
 
 auto env_applier = [](open_wrapper fd) -> int
 {
-    auto env_splitter = line_splitter_make(env_putter, '\0');
+    auto env_splitter = line_splitter_make(&env_putter, '\0');
 
     char buf[BUFSIZ];
     ssize_t count;

--- a/lib/ccsh_command.cpp
+++ b/lib/ccsh_command.cpp
@@ -80,7 +80,7 @@ void command_native::start_run(int in, int out, int err, std::vector<int> unused
         if (CCSH_RETRY_HANDLER(fcntl(fail_pipe[1], F_SETFD, FD_CLOEXEC)) < 0)
             goto fail;
 
-        execvp(argv[0], (char* const*)argv.data());
+        execvp(argv[0], const_cast<char* const*>(argv.data()));
 fail:
         int fail_code = errno;
         CCSH_RETRY_HANDLER(write(fail_pipe[1], &fail_code, sizeof(int)));
@@ -196,11 +196,11 @@ void command_err_mapping::start_run(int in, int out, int, std::vector<int> unuse
     if (init_func) init_func();
 
     int pipefd[2];
+    stdc_thrower(pipe(pipefd));
     unused_fds.push_back(pipefd[0]);
     open_wrapper temp0{pipefd[0]};
     open_wrapper temp1{pipefd[1]};
 
-    stdc_thrower(pipe(pipefd));
     auto f2 = [this, pipefd](open_wrapper fd)
     {
         char buf[BUFSIZ];

--- a/lib/ccsh_command.cpp
+++ b/lib/ccsh_command.cpp
@@ -5,9 +5,9 @@
 #include <sys/wait.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
-#include <string.h>
+#include <cstring>
 
 #include <iostream>
 #include <utility>
@@ -219,9 +219,9 @@ void command_err_mapping::start_run(int in, int out, int, std::vector<int> unuse
 }
 
 template<stdfd DESC>
-command_redirect<DESC>::command_redirect(command const& c, fs::path const& p, bool append)
-    : c(c)
-    , p(p)
+command_redirect<DESC>::command_redirect(command c, fs::path p, bool append)
+    : c(std::move(c))
+    , p(std::move(p))
     , flags(fopen_flags(DESC, append))
 { }
 
@@ -245,8 +245,8 @@ class command_redirect<stdfd::err>;
 
 
 template<stdfd DESC>
-command_fd<DESC>::command_fd(command const& c, int fd)
-    : c(c)
+command_fd<DESC>::command_fd(command c, int fd)
+    : c(std::move(c))
     , ow(fd)
 { }
 
@@ -279,7 +279,7 @@ void replace(std::string& str, std::string const& from, std::string const& to)
 std::string sh_escape(std::string const& str)
 {
     std::string temp = str;
-    replace(temp, "'", "'\\''");
+    replace(temp, "'", R"('\'')");
     return " '" + temp + "' ";
 }
 

--- a/lib/ccsh_fdstream.cpp
+++ b/lib/ccsh_fdstream.cpp
@@ -1,9 +1,9 @@
-#include <ccsh/ccsh_fdstream.hpp>
 #include "ccsh_internals.hpp"
+#include <ccsh/ccsh_fdstream.hpp>
 
 #include <cstdio>
-#include <unistd.h>
 #include <cstring>
+#include <unistd.h>
 
 namespace ccsh {
 namespace internal {
@@ -62,6 +62,6 @@ int ifdstreambuf::underflow()
     return traits_type::to_int_type(*gptr());
 }
 
-}
-}
+} // namespace internal
+} // namespace ccsh
 

--- a/lib/ccsh_filesystem.cpp
+++ b/lib/ccsh_filesystem.cpp
@@ -3,7 +3,8 @@
 
 #if defined(CCSH_FILESYSTEM_BOOST) && BOOST_VERSION >= 106000
 
-namespace ccsh { namespace fs {
+namespace ccsh {
+namespace fs {
 
 path self_lexically_relative(path const& self, path const& base)
 {
@@ -15,14 +16,16 @@ path self_lexically_normal(path const& self)
     return self.lexically_normal();
 }
 
-}}
+} // namespace fs
+} // namespace ccsh
 
 #else
 
 // Code below was taken from boost source.
 // See http://www.boost.org/users/license.html for license.
 
-namespace ccsh { namespace fs {
+namespace ccsh {
+namespace fs {
 
 namespace {
 
@@ -43,7 +46,7 @@ inline std::pair<path::iterator, path::iterator> mismatch(path::iterator it1, pa
     return std::make_pair(it1, it2);
 }
 
-}
+} // namespace
 
 
 path self_lexically_relative(path const& self, path const& base)
@@ -142,6 +145,7 @@ path self_lexically_normal(path const& self)
     return temp;
 }
 
-}}
+} // namespace fs
+} // namespace ccsh
 
 #endif

--- a/lib/ccsh_filesystem.cpp
+++ b/lib/ccsh_filesystem.cpp
@@ -98,7 +98,7 @@ path self_lexically_normal(path const& self)
             && (itr->native())[1] == dot) // dot dot
         {
             path::string_type lf(temp.filename().native());
-            if (lf.size() > 0
+            if (!lf.empty()
                 && (lf.size() != 1
                     || (lf[0] != dot
                         && lf[0] != slash))

--- a/lib/ccsh_internals.hpp
+++ b/lib/ccsh_internals.hpp
@@ -10,7 +10,8 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-namespace ccsh { namespace internal {
+namespace ccsh {
+namespace internal {
 
 template<typename FUNC>
 int retry_handler(FUNC&& func)
@@ -114,6 +115,7 @@ void tokenize_string(std::string const& str, std::string const& delimiters, FUNC
     }
 }
 
-}} // namespace ccsh::internal
+} // namespace internal
+} // namespace ccsh
 
 #endif // CCSH_INTERNALS_HPP_INCLUDED

--- a/lib/ccsh_internals.hpp
+++ b/lib/ccsh_internals.hpp
@@ -4,6 +4,7 @@
 #include <ccsh/ccsh_utils.hpp>
 
 #include <string>
+#include <type_traits>
 #include <cstring>
 #include <cstddef>
 #include <cstdint>
@@ -69,7 +70,7 @@ class line_splitter
     FUNC func;
     char delim;
 public:
-    explicit line_splitter(FUNC&& func, char delim = '\n')
+    explicit line_splitter(FUNC func, char delim = '\n')
         : func(std::move(func))
         , delim(delim)
     { }
@@ -94,11 +95,9 @@ public:
 };
 
 template<typename FUNC>
-line_splitter<FUNC> line_splitter_make(FUNC&& func, char delim = '\n')
+line_splitter<typename std::remove_reference<FUNC>::type> line_splitter_make(FUNC&& func, char delim = '\n')
 {   // Comes handy when you have a lambda.
-    // If you see an error here: *call this function only with rvalues*!
-    // Cannot be done better without type_traits because of "forwarding reference".
-    return line_splitter<FUNC>(std::forward<FUNC>(func), delim);
+    return line_splitter<typename std::remove_reference<FUNC>::type>(std::forward<FUNC>(func), delim);
 }
 
 template<typename FUNC>

--- a/lib/ccsh_internals.hpp
+++ b/lib/ccsh_internals.hpp
@@ -77,7 +77,7 @@ public:
     {
         char* newline;
         std::size_t si = s;
-        while (si > 0 && (newline = (char*)memchr(buf, delim, si)))
+        while (si > 0 && (newline = (char*)memchr(buf, delim, si)) != nullptr)
         {
             std::size_t diff = newline - buf;
             temp.append(buf, diff);

--- a/lib/ccsh_operators.cpp
+++ b/lib/ccsh_operators.cpp
@@ -1,5 +1,5 @@
-#include <ccsh/ccsh_operators.hpp>
 #include "ccsh_internals.hpp"
+#include <ccsh/ccsh_operators.hpp>
 
 #include <cstring>
 #include <functional>

--- a/lib/ccsh_operators.cpp
+++ b/lib/ccsh_operators.cpp
@@ -18,7 +18,7 @@ command_runnable operator<(command const& c, std::string& str)
         std::size_t len = str.length();
         len = len < s ? len : s;
         std::memcpy(buf, str.data(), len);
-        if (len)
+        if (len != 0)
             str.erase(0, len);
         return len;
     };
@@ -67,12 +67,10 @@ command_runnable operator<(command const& c, std::vector<std::string>& vec)
             vec.erase(vec.begin()); // shit
             return len + 1;
         }
-        else
-        {
-            std::memcpy(buf, str.data(), s);
-            str.erase(0, s);
-            return s;
-        }
+        
+        std::memcpy(buf, str.data(), s);
+        str.erase(0, s);
+        return s;
     };
     return {new command_in_mapping(c, func)};
 }

--- a/lib/ccsh_operators.cpp
+++ b/lib/ccsh_operators.cpp
@@ -67,7 +67,7 @@ command_runnable operator<(command const& c, std::vector<std::string>& vec)
             vec.erase(vec.begin()); // shit
             return len + 1;
         }
-        
+
         std::memcpy(buf, str.data(), s);
         str.erase(0, s);
         return s;
@@ -79,7 +79,7 @@ command_runnable operator>(command const& c, std::vector<std::string>& vec)
 {
     auto pusher = [&vec](std::string&& str)
     { vec.push_back(std::move(str)); };
-    return {new command_out_mapping(c, line_splitter_make(std::move(pusher)),
+    return {new command_out_mapping(c, line_splitter_make(pusher),
                                     std::bind(&std::vector<std::string>::clear, std::ref(vec)))};
 }
 
@@ -87,14 +87,14 @@ command_runnable operator>>(command const& c, std::vector<std::string>& vec)
 {
     auto pusher = [&vec](std::string&& str)
     { vec.push_back(std::move(str)); };
-    return {new command_out_mapping(c, line_splitter_make(std::move(pusher)))};
+    return {new command_out_mapping(c, line_splitter_make(pusher))};
 }
 
 command_runnable operator>=(command const& c, std::vector<std::string>& vec)
 {
     auto pusher = [&vec](std::string&& str)
     { vec.push_back(std::move(str)); };
-    return {new command_err_mapping(c, line_splitter_make(std::move(pusher)),
+    return {new command_err_mapping(c, line_splitter_make(pusher),
                                     std::bind(&std::vector<std::string>::clear, std::ref(vec)))};
 }
 
@@ -102,7 +102,7 @@ command_runnable operator>>=(command const& c, std::vector<std::string>& vec)
 {
     auto pusher = [&vec](std::string&& str)
     { vec.push_back(std::move(str)); };
-    return {new command_err_mapping(c, line_splitter_make(std::move(pusher)))};
+    return {new command_err_mapping(c, line_splitter_make(pusher))};
 }
 
 /* ******************* vector redirection operators ******************* */

--- a/lib/ccsh_utils.cpp
+++ b/lib/ccsh_utils.cpp
@@ -1,12 +1,12 @@
-#include <ccsh/ccsh_utils.hpp>
 #include "ccsh_internals.hpp"
+#include <ccsh/ccsh_utils.hpp>
 
+#include <climits>
 #include <cstring>
+#include <glob.h>
+#include <pwd.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <climits>
-#include <pwd.h>
-#include <glob.h>
 
 #include <memory>
 
@@ -27,7 +27,7 @@ void expand_helper(path const& p, std::vector<path>& result)
     globfree(&globbuf);
 }
 
-}
+} // namespace
 
 std::vector<path> expand(path const& p)
 {
@@ -44,7 +44,7 @@ std::vector<path> expand(std::vector<path> const& paths)
     return result;
 }
 
-}
+} // namespace fs
 
 fs::path get_home()
 {
@@ -176,6 +176,5 @@ static_assert(int(stdfd::in) == STDIN_FILENO, "Error in stdfd enum.");
 static_assert(int(stdfd::out) == STDOUT_FILENO, "Error in stdfd enum.");
 static_assert(int(stdfd::err) == STDERR_FILENO, "Error in stdfd enum.");
 
-}
-
+} // namespace internal
 } // namespace ccsh

--- a/lib/ccsh_utils.cpp
+++ b/lib/ccsh_utils.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <sys/types.h>
 #include <unistd.h>
-#include <limits.h>
+#include <climits>
 #include <pwd.h>
 #include <glob.h>
 
@@ -19,10 +19,10 @@ namespace {
 void expand_helper(path const& p, std::vector<path>& result)
 {
     glob_t globbuf;
-    glob(p.string().c_str(), GLOB_NOCHECK | GLOB_TILDE_CHECK, NULL, &globbuf);
+    glob(p.string().c_str(), GLOB_NOCHECK | GLOB_TILDE_CHECK, nullptr, &globbuf);
 
     for (std::size_t i = 0; i < globbuf.gl_pathc; ++i)
-        result.push_back(globbuf.gl_pathv[i]);
+        result.emplace_back(globbuf.gl_pathv[i]);
 
     globfree(&globbuf);
 }

--- a/lib/ccsh_utils.cpp
+++ b/lib/ccsh_utils.cpp
@@ -139,7 +139,7 @@ void env_var::set(std::string const& name, std::string const& value, bool overri
 
 int env_var::try_set(std::string const& name, std::string const& value, bool override)
 {
-    return setenv(name.c_str(), value.c_str(), override);
+    return setenv(name.c_str(), value.c_str(), int(override));
 }
 
 stdc_error::stdc_error(int no)
@@ -160,7 +160,7 @@ env_var::operator std::string() const
 
 env_var& env_var::operator=(std::string const& str)
 {
-    internal::stdc_thrower(setenv(name.c_str(), str.c_str(), true));
+    internal::stdc_thrower(setenv(name.c_str(), str.c_str(), int(true)));
     return *this;
 }
 

--- a/lib/ccsh_utils.cpp
+++ b/lib/ccsh_utils.cpp
@@ -51,7 +51,7 @@ fs::path get_home()
     struct passwd pwd;
     struct passwd* result;
 
-    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    auto bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
     if (bufsize == -1)
         bufsize = 16384;
 

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -47,9 +47,8 @@ void test0()
 void test1()
 {
     using namespace ccsh;
-    command c1 = cat().e();
-    auto c2 = c1;
-    command_builder<cat> x = cat().n();
+    ccsh::command c1 = cat().e();
+    ccsh::command_builder<cat> x = cat().n();
 
     x.T();
 }

--- a/test/test1.cpp
+++ b/test/test1.cpp
@@ -1,7 +1,7 @@
 #include <ccsh/ccsh.hpp>
 #include <cstdio>
-#include <string>
 #include <fstream>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/test/test1.cpp
+++ b/test/test1.cpp
@@ -7,7 +7,7 @@
 
 using namespace ccsh;
 
-std::string ReadAllText(fs::path filename)
+std::string ReadAllText(fs::path const& filename)
 {
     std::ifstream t(filename.c_str());
     return std::string(std::istreambuf_iterator<char>(t),

--- a/test/test2.cpp
+++ b/test/test2.cpp
@@ -1,7 +1,7 @@
 #include <ccsh/ccsh.hpp>
 #include <cstdio>
-#include <string>
 #include <fstream>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/wrappers/ccsh/core/base3264.hpp
+++ b/wrappers/ccsh/core/base3264.hpp
@@ -34,6 +34,6 @@ CCSH_WRAPPER_COMMON_CLASS(base_t, base64_t, "base64")
 using base32 = command_holder<base32_t>;
 using base64 = command_holder<base64_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_BASE3264_HPP_INCLUDED

--- a/wrappers/ccsh/core/cat.hpp
+++ b/wrappers/ccsh/core/cat.hpp
@@ -47,6 +47,6 @@ public:
 
 using cat = command_holder<cat_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_CAT_HPP_INCLUDED

--- a/wrappers/ccsh/core/cksum.hpp
+++ b/wrappers/ccsh/core/cksum.hpp
@@ -21,6 +21,6 @@ public:
 
 using cksum = command_holder<cksum_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_CKSUM_HPP_INCLUDED

--- a/wrappers/ccsh/core/fmt.hpp
+++ b/wrappers/ccsh/core/fmt.hpp
@@ -42,6 +42,6 @@ public:
 
 using fmt = command_holder<fmt_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_FMT_HPP_INCLUDED

--- a/wrappers/ccsh/core/fold.hpp
+++ b/wrappers/ccsh/core/fold.hpp
@@ -30,6 +30,6 @@ public:
 
 using fold = command_holder<fold_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_FOLD_HPP_INCLUDED

--- a/wrappers/ccsh/core/head.hpp
+++ b/wrappers/ccsh/core/head.hpp
@@ -2,8 +2,8 @@
 #define CCSH_CORE_HEAD_HPP_INCLUDED
 
 #include <ccsh/ccsh_command.hpp>
-#include <ccsh/ccsh_wrappers.hpp>
 #include <ccsh/ccsh_ratio.hpp>
+#include <ccsh/ccsh_wrappers.hpp>
 
 namespace ccsh {
 
@@ -43,6 +43,6 @@ public:
 
 using head = command_holder<head_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_HEAD_HPP_INCLUDED

--- a/wrappers/ccsh/core/ls.hpp
+++ b/wrappers/ccsh/core/ls.hpp
@@ -337,12 +337,12 @@ template<typename T> constexpr const char * ls_t<T>::color_type_mapping[];
 template<typename T> constexpr typename ls_t<T>::none_t ls_t<T>::none;
 template<typename T> constexpr typename ls_t<T>::locale_t ls_t<T>::locale;
 
-}
+}  // namespace hidden
 
 using ls_t = hidden::ls_t<>;
 
 using ls = command_holder<ls_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_LS_HPP_INCLUDED

--- a/wrappers/ccsh/core/nl.hpp
+++ b/wrappers/ccsh/core/nl.hpp
@@ -2,8 +2,8 @@
 #define CCSH_CORE_NL_HPP_INCLUDED
 
 #include <ccsh/ccsh_command.hpp>
-#include <ccsh/ccsh_wrappers.hpp>
 #include <ccsh/ccsh_regex.hpp>
+#include <ccsh/ccsh_wrappers.hpp>
 
 namespace ccsh {
 
@@ -95,6 +95,6 @@ public:
 
 using nl = command_holder<nl_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_NL_HPP_INCLUDED

--- a/wrappers/ccsh/core/pr.hpp
+++ b/wrappers/ccsh/core/pr.hpp
@@ -120,6 +120,6 @@ public:
 using pr = command_holder<pr_t>;
 
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_PR_HPP_INCLUDED

--- a/wrappers/ccsh/core/shasum.hpp
+++ b/wrappers/ccsh/core/shasum.hpp
@@ -56,6 +56,6 @@ using sha256sum = command_holder<sha256sum_t>;
 using sha384sum = command_holder<sha384sum_t>;
 using sha512sum = command_holder<sha512sum_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_SHASUM_HPP_INCLUDED

--- a/wrappers/ccsh/core/sum.hpp
+++ b/wrappers/ccsh/core/sum.hpp
@@ -26,6 +26,6 @@ public:
 
 using sum = command_holder<sum_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_SUM_HPP_INCLUDED

--- a/wrappers/ccsh/core/tac.hpp
+++ b/wrappers/ccsh/core/tac.hpp
@@ -30,6 +30,6 @@ public:
 using tac = command_holder<tac_t>;
 
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_TAC_HPP_INCLUDED

--- a/wrappers/ccsh/core/tail.hpp
+++ b/wrappers/ccsh/core/tail.hpp
@@ -4,8 +4,8 @@
 #include <chrono>
 
 #include <ccsh/ccsh_command.hpp>
-#include <ccsh/ccsh_wrappers.hpp>
 #include <ccsh/ccsh_ratio.hpp>
+#include <ccsh/ccsh_wrappers.hpp>
 
 namespace ccsh {
 
@@ -70,6 +70,6 @@ public:
 
 using tail = command_holder<tail_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_TAIL_HPP_INCLUDED

--- a/wrappers/ccsh/core/wc.hpp
+++ b/wrappers/ccsh/core/wc.hpp
@@ -38,6 +38,6 @@ public:
 
 using wc = command_holder<wc_t>;
 
-}
+}  // namespace ccsh
 
 #endif // CCSH_CORE_WC_HPP_INCLUDED


### PR DESCRIPTION
```
clang-tidy "-header-filter=.*/ccsh/.*\.hpp" -checks=-*,modernize-*,-modernize-use-equals-default,-modernize-use-equals-delete `find . -wholename "./*.cpp"`

clang-tidy "-header-filter=.*/ccsh/.*\.hpp" -checks=-*,google-*,-google-readability-braces-around-statements,-google-runtime-references,-google-readability-todo,-google-build-using-namespace,-google-explicit-constructor `find . -wholename "./*.cpp"`

clang-tidy "-header-filter=.*/ccsh/.*\.hpp" -checks=-*,llvm-*,-llvm-header-guard,-llvm-include-order `find . -wholename "./*.cpp"`

clang-tidy "-header-filter=.*/ccsh/.*\.hpp" -checks=-*,performance-*,-performance-unnecessary-value-param `find . -wholename "./*.cpp"`

clang-tidy "-header-filter=.*/ccsh/.*\.hpp" -checks=-*,readability-*,-readability-named-parameter,-readability-braces-around-statements,-readability-inconsistent-declaration-parameter-name,-readability-redundant-declaration `find . -wholename "./*.cpp"`

clang-tidy "-header-filter=.*/ccsh/.*\.hpp" -checks=-*,misc-*,-misc-noexcept-move-constructor,-misc-macro-parentheses `find . -wholename "./*.cpp"`

clang-tidy "-header-filter=.*/ccsh/.*\.hpp" -checks=-*,boost-* `find . -wholename "./*.cpp"`

clang-tidy "-header-filter=.*/ccsh/.*\.hpp" -checks=-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-member-init,-cppcoreguidelines-special-member-functions,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-type-const-cast `find . -wholename "./*.cpp"`
```